### PR TITLE
Add simple tools for dependency management and build automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+GO ?= go
+GOGUACAMOLE_PACKAGE=github.com/goplate/goguacamole
+
+install:
+		$(GO) install ${GOGUACAMOLE_PACKAGE}
+
+.PHONY: install

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,16 @@
+# Glide YAML configuration file
+package: github.com/goplate/goguacamole
+
+# Declare your project's dependencies.
+import:
+  # Fetch package similar to 'go get':
+  #- package: github.com/Masterminds/cookoo
+  # Get and manage a package with Git:
+  #- package: github.com/Masterminds/cookoo
+  #  # The repository URL
+  #  repo: git@github.com:Masterminds/cookoo.git
+  #  # A tag, branch, or SHA
+  #  ref: 1.1.0
+  #  # the VCS type (compare to bzr, hg, svn). You should
+  #  # set this if you know it.
+  #  vcs: git

--- a/goguacamole.go
+++ b/goguacamole.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("hello, world!\n")
+}


### PR DESCRIPTION
Added two tools before doing any serious development to ensure we start with a proper directory structure for the project. I checked couple of possibilities and picked these two:
- [Glide](https://github.com/Masterminds/glide) for dependency management - simple to use and respects `vendor` directory introduced in Go 1.5. We can follow workspace layout suggested by Go devs (https://golang.org/doc/code.html). Standard layout easily integrates with existing Golang IDEs (e.g. Atom, I still need to check how IDEA works).
- `go build` and `go install` commands work as a charm, so we don't really need any complicated tools yet. I picked up simple `Makefile`, because it's most commonly used among the most popular Go repositories in github. Additionally, we may need to add some linker flags later on, which will be easy with `Makefile`.

Resolves #1 and #5.
